### PR TITLE
Rename ally tool to _ally and update ZSH function

### DIFF
--- a/function.sh
+++ b/function.sh
@@ -1,30 +1,11 @@
-function _ally::reload() {
-    # Reload the current terminal session
-    source ~/.ally
-}
-# TODO: The function can take in arguments, so we need to fix the "unalias" part 
-#       to unalias the correct alias, rather than some flag
-function _ally::unalias() {
-    # Parse the args
-    # Call ally, then unalias $1 and source ~/.ally
-    ally $@
-    # Get the part that is not a flag
-    for arg in $@; do
-        if [[ $arg != -* ]]; then
-            if [[ $arg == $1 ]]; then
-                continue
-            fi
-            unalias $arg
-            break
-        fi
-    done
-    _ally::reload
-}
-function ally_function() {
-    # Call the ally cli tool with all args
-    if [ "$1" = "remove" ]; then
-        _ally::unalias $@
+function ally {
+    # Check for --no-reload flag
+    if [[ " $* " =~ "--no-reload" ]]; then
+        # Call the _ally cli tool with all args except --no-reload
+        _ally "${@/--no-reload/}"
     else
-        ally $@
+        # Call the _ally cli tool with all args and reload
+        _ally $@
+        source ~/.ally
     fi
 }

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,7 @@
 #!/bin/zsh
+
+# This script installs the Ally tool and is likely used via CuRL from the server in a one-liner
+
 function ask_for_continue() {
     read -n 1 -r -p "[PERMISSION] Continue? (y/n) "
     echo    # (optional) move to a new line
@@ -8,11 +11,8 @@ function ask_for_continue() {
     else
         exit 1
     fi
-
 }
 
-# This script installs the Ally tool and is likely used via CuRL from the server in a one-liner
-# First off, clone the repo and use `swift build` to build ally
 echo "[ALLY-SYSTEM]: Welcome to Ally! Ally is a simple, lightweight tool to work with ZSH aliases. It uses pure sh code, so there is no vendor lock-in. This script will explain what it does and ask for permission before doing so."
 echo "[ALLY-SYSTEM] This install script will now clone the Git Repo from GitHub in order to build Ally. Install git from https://git-scm.com if you do not have it installed."
 
@@ -22,26 +22,34 @@ cd Ally
 echo "[ALLY-SYSTEM] The script will now build the CLI tool."
 ask_for_continue
 swift build -c release --build-path ~/ally
-# Then, move the binary to /usr/local/bin
-echo "[ALLY_SYSTEM] The next step requires sudo access in order to move the built binary to your bin. It will only move the built ally binary."
+# Then, move the binary to /usr/local/bin and rename it to _ally
+echo "[ALLY_SYSTEM] The next step requires sudo access in order to move the built binary to your bin and rename it to _ally. It will only move the built ally binary."
 ask_for_continue
-sudo mv ~/ally/release/ally /usr/local/bin/ally
+sudo mv ~/ally/release/ally /usr/local/bin/_ally
 # Then, remove the build folder
 rm -rf ~/ally
 # Then, remove the repo
 cd ..
 rm -rf Ally
-echo "[ALLY-SYSTEM] Ally is now installed, and all superflous directories created in install are cleaned up!"
-    read -n 1 -r -p "Initialize Ally? (y/n) "
-    echo    # (optional) move to a new line
-    if [[ $REPLY =~ ^[Yy]$ ]]
-    then
-        echo "Initializing..."
-    else
-        exit 1
-    fi
+echo "[ALLY-SYSTEM] Ally is now installed as _ally, and all superfluous directories created in install are cleaned up!"
+
+read -n 1 -r -p "Initialize Ally? (y/n) "
+echo    # (optional) move to a new line
+if [[ $REPLY =~ ^[Yy]$ ]]
+then
+    echo "Initializing..."
+else
+    exit 1
+fi
+
 # Now, run `ally init`
-/usr/local/bin/ally init
+/usr/local/bin/_ally init
+
+# Add the function specified in `function.sh` to .zshrc
+echo "Adding Ally function to .zshrc for automatic terminal reload..."
+# Directly cat the contents of function.sh during install (via CURLing the file) and then, using >>, add then to .zshrc.
+curl -fsSL https://raw.githubusercontent.com/OCA-Creations/Ally/main/function.sh >> ~/.zshrc
+
 # Finally, ally is now installed and ready to use!
 echo "Ally is now installed and ready to use! You need to reload your terminal to use it:"
 echo -e "\033[1msource ~/.zshrc\033[0m"


### PR DESCRIPTION
Implements automatic terminal reload and tool renaming during installation for Ally.

- Renames the Ally tool to _ally during installation in `install.sh`, ensuring it aligns with the new naming convention.
- Adds a ZSH function to the user's `.zshrc` file for automatic terminal reload, facilitating a smoother user experience by sourcing `.ally` after command execution.
- Updates `function.sh` to call the _ally command instead of ally, incorporating logic to handle `--no-reload` flag which allows users to opt-out of automatic reloading if desired.
- Streamlines the installation process by directly appending the contents of `function.sh` to `.zshrc`, removing the need for manual function addition.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/OCA-Creations/Ally?shareId=7ee7ff31-26a8-46d2-a7f3-0a84f52cdad7).